### PR TITLE
fix: add templates to the build artifacts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,8 @@ exclude = [
 [tool.hatch.build.targets.wheel.shared-data]
 "data/patches" = "share/slurm-factory/patches"
 "data/lxd-profile.yaml" = "share/slurm-factory/lxd-profile.yaml"
+"data/templates" = "share/slurm-factory/templates"
+
 
 [tool.hatch.build.targets.sdist]
 exclude = [


### PR DESCRIPTION
These changes ensure the templates directory is copied to the built sdist/wheel.